### PR TITLE
Add transaction reconstruction check

### DIFF
--- a/My_blockchain.py
+++ b/My_blockchain.py
@@ -347,6 +347,10 @@ def run_tests():
     tx.sign(acct['private_key'])
     assert tx.verify_signature(), "Signature verification failed"
     assert bc.is_valid_transaction(tx), "Valid transaction marked invalid"
+    d = tx.to_dict()
+    tx2 = Transaction(**d)
+    assert tx2.from_address == tx.from_address
+    assert tx2.to_address == tx.to_address
 
     print("All tests passed.")
 


### PR DESCRIPTION
## Summary
- ensure transactions reconstruct correctly from `to_dict` in tests

## Testing
- `python3 My_blockchain.py` *(fails: No module named 'ecdsa')*

------
https://chatgpt.com/codex/tasks/task_e_688a4e2b00908333940f0ae44bc87709