### PR TITLE
Fix block reconstruction on load

### DIFF
--- a/My_blockchain.py
+++ b/My_blockchain.py
@@ -220,7 +220,7 @@ class Blockchain(MiningChain):
                 if not rows:
                     return
                 for idx, raw in rows:
-                    blk = Block(**raw)
+                    blk = Block(**json.loads(raw))
                     self.chain.append(blk)
                 cur.execute("SELECT address, balance FROM balances")
                 for addr, bal in cur.fetchall():


### PR DESCRIPTION
## Summary
- parse JSON block records correctly when loading from the database

## Testing
- `python3 My_blockchain.py` *(fails: ModuleNotFoundError: No module named 'ecdsa')*
- `pip install ecdsa` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688a4e08089c8333a55ff2ad2029c879