### PR TITLE
Fix chain init parameters

### DIFF
--- a/My_blockchain.py
+++ b/My_blockchain.py
@@ -21,8 +21,7 @@ from cryptography.hazmat.primitives import serialization
 from pysnark.runtime import snark, PrivVal
 
 # --- Smart Contracts / EVM ---
-from eth.chains.base import MiningChain
-from eth.vm.forks.berlin import BerlinVM
+
 from web3 import Web3
 
 # --- DB & Environment ---
@@ -198,9 +197,8 @@ class ShieldedTransaction:
         return snark.verify(self.proof, vk)
 
 # --- Blockchain with EVM & P2P ---
-class Blockchain(MiningChain):
+class Blockchain:
     def __init__(self, db_pool):
-        super().__init__(genesis_params={}, genesis_state={})
         self.db_pool = db_pool
         self.chain = []
         self.balances = {}


### PR DESCRIPTION
## Summary
- drop unused MiningChain/BerlinVM imports
- remove MiningChain inheritance so no genesis params are passed

## Testing
- `python3 My_blockchain.py` *(fails: No module named 'ecdsa')*

------
https://chatgpt.com/codex/tasks/task_e_688a562f3e0483339edd5e30006a9af3