### PR TITLE
Fix weights filename extension

### DIFF
--- a/My_blockchain.py
+++ b/My_blockchain.py
@@ -149,7 +149,7 @@ class HDWallet:
         return {"private_key": priv_hex, "address": addr}
 
 # --- Autoencoder persistence ---
-AUTOENCODER_FILE = "autoencoder.h5"
+AUTOENCODER_FILE = "autoencoder.weights.h5"
 if tf and layers:
     autoencoder = tf.keras.Sequential([
         layers.Dense(32, activation='relu', input_shape=(4,)),


### PR DESCRIPTION
## Summary
- save and load autoencoder weights with `.weights.h5` suffix

## Testing
- `python My_blockchain.py`

------
https://chatgpt.com/codex/tasks/task_e_688a63e337c4833396085bdaf71c66ab