### PR TITLE
Fix transaction signature verification

### DIFF
--- a/My_blockchain.py
+++ b/My_blockchain.py
@@ -271,7 +271,8 @@ class Transaction:
 
     def sign(self, priv_hex):
         if keys:
-            sig = keys.PrivateKey(bytes.fromhex(priv_hex)).sign_msg(self._hash())
+            priv = keys.PrivateKey(bytes.fromhex(priv_hex))
+            sig = priv.sign_msg_hash(self._hash())
             self.signature = sig.to_bytes().hex()
         else:
             priv = bytes.fromhex(priv_hex)
@@ -285,7 +286,7 @@ class Transaction:
         sig_bytes = bytes.fromhex(self.signature)
         if keys:
             sig = keys.Signature(sig_bytes)
-            pub = sig.recover_public_key_from_msg(self._hash())
+            pub = sig.recover_public_key_from_msg_hash(self._hash())
             return derive_address_from_pubkey(pub.to_bytes()) == self.from_address
         else:
             pub = sig_bytes[:32]


### PR DESCRIPTION
## Summary
- switch Ethereum signing to sign message hash
- update verification to recover public key from message hash

## Testing
- `python3 My_blockchain.py`

------
https://chatgpt.com/codex/tasks/task_e_688a670fd82c8333aa5e94d6cf4dca2b