### PR TITLE
chore: add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run compilation check
+        run: |
+          python -m py_compile My_blockchain.py wallet.py
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ Edit this file to customize your network before launching the node or wallet.
 * **Step 3:** Use your wallet to receive mined tokens and send transactions
 * **Step 4:** (Optional) Enable CoinJoin for maximum privacy
 
+## 📦 Automated Releases
+
+A GitHub Actions workflow publishes a release whenever a tag starting with `v` is pushed. It installs dependencies, performs a compilation check, and automatically generates release notes.
+
 ---
 
 If you want, I can now **generate this README as a professional PDF with charts** showing:


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish releases on tags
- document automated release process in README

## Testing
- `python -m py_compile My_blockchain.py wallet.py`


------
https://chatgpt.com/codex/tasks/task_e_6895a6d64a988333934d51c7fe623aad