### PR TITLE
feat: add qnn transaction validator

### DIFF
--- a/server/qnn-validator.ts
+++ b/server/qnn-validator.ts
@@ -1,0 +1,131 @@
+import { EventEmitter } from 'events';
+
+export interface QuantumTransactionData {
+  from: string;
+  to: string;
+  amount: number;
+  payload?: Record<string, unknown>;
+}
+
+export interface QNNValidationResult {
+  transactionHash: string;
+  quantumScore: number;
+  riskLevel: string;
+  warnings: string[];
+  valid: boolean;
+  details?: Record<string, unknown>;
+}
+
+export interface QNNStats {
+  totalProcessed: number;
+  quantumNeuronsActive: number;
+  validationErrors: number;
+  lastProcessedTimestamp?: number;
+}
+
+// Stub implementations for services and helpers
+export async function startQNNService(): Promise<void> {
+  // Placeholder for starting the quantum neural network service
+  return Promise.resolve();
+}
+
+export async function startZKService(): Promise<void> {
+  // Placeholder for starting the zero-knowledge proof service
+  return Promise.resolve();
+}
+
+export async function runQuantumAnalysis(_tx: QuantumTransactionData): Promise<number> {
+  // Placeholder quantum analysis
+  return Math.random();
+}
+
+export async function runClassicalAnalysis(_tx: QuantumTransactionData): Promise<number> {
+  // Placeholder classical analysis
+  return Math.random();
+}
+
+export async function validateZKProof(_tx: QuantumTransactionData): Promise<boolean> {
+  // Placeholder ZK proof validation
+  return true;
+}
+
+export function calculateRiskLevel(quantumScore: number, classicalScore: number): string {
+  const combined = (quantumScore + classicalScore) / 2;
+  if (combined > 0.8) return 'low';
+  if (combined > 0.4) return 'medium';
+  return 'high';
+}
+
+export function generateWarnings(riskLevel: string): string[] {
+  switch (riskLevel) {
+    case 'medium':
+      return ['Review recommended'];
+    case 'high':
+      return ['Manual review required'];
+    default:
+      return [];
+  }
+}
+
+export class QNNTransactionValidator extends EventEmitter {
+  private queue: QuantumTransactionData[] = [];
+  private processing = false;
+
+  public stats: QNNStats = {
+    totalProcessed: 0,
+    quantumNeuronsActive: 0,
+    validationErrors: 0,
+  };
+
+  async initializeQNNValidator(): Promise<void> {
+    await startQNNService();
+    await startZKService();
+  }
+
+  enqueue(tx: QuantumTransactionData): void {
+    this.queue.push(tx);
+    this.processNext();
+  }
+
+  private async processNext(): Promise<void> {
+    if (this.processing) return;
+    const tx = this.queue.shift();
+    if (!tx) return;
+    this.processing = true;
+
+    try {
+      const result = await this.validateTransaction(tx);
+      this.stats.totalProcessed += 1;
+      this.stats.lastProcessedTimestamp = Date.now();
+      this.emit('validated', result);
+    } catch (err) {
+      this.stats.validationErrors += 1;
+      this.emit('error', err);
+    } finally {
+      this.processing = false;
+      if (this.queue.length > 0) {
+        this.processNext();
+      }
+    }
+  }
+
+  async validateTransaction(tx: QuantumTransactionData): Promise<QNNValidationResult> {
+    const quantumScore = await runQuantumAnalysis(tx);
+    const classicalScore = await runClassicalAnalysis(tx);
+    const zkValid = await validateZKProof(tx);
+    const riskLevel = calculateRiskLevel(quantumScore, classicalScore);
+    const warnings = generateWarnings(riskLevel);
+
+    return {
+      transactionHash: (tx.payload as any)?.hash || '',
+      quantumScore,
+      riskLevel,
+      warnings,
+      valid: zkValid,
+      details: { classicalScore },
+    };
+  }
+}
+
+export const qnnValidator = new QNNTransactionValidator();
+export default qnnValidator;


### PR DESCRIPTION
## Summary
- add QNNTransactionValidator with queue management and stats interfaces
- include stubbed services for QNN, ZK, and analysis helpers
- export reusable qnnValidator instance

## Testing
- `npm test` *(fails: no package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68984fd199608333b24c449187d8acd7