### PR TITLE
feat: add drizzle schema

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,0 +1,34 @@
+import { pgTable, serial, text, integer, timestamp, decimal } from "drizzle-orm/pg-core";
+
+export const wallets = pgTable("wallets", {
+  id: serial("id").primaryKey(),
+  address: text("address").notNull().unique(),
+  balance: decimal("balance", { precision: 20, scale: 8 }).notNull().default("0"),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const multiWalletAddresses = pgTable("multi_wallet_addresses", {
+  id: serial("id").primaryKey(),
+  walletId: integer("wallet_id").references(() => wallets.id).notNull(),
+  address: text("address").notNull().unique(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const zkChatMessages = pgTable("zk_chat_messages", {
+  id: serial("id").primaryKey(),
+  walletId: integer("wallet_id").references(() => wallets.id).notNull(),
+  message: text("message").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const miningRewards = pgTable("mining_rewards", {
+  id: serial("id").primaryKey(),
+  walletId: integer("wallet_id").references(() => wallets.id).notNull(),
+  amount: decimal("amount", { precision: 20, scale: 8 }).notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export type Wallet = typeof wallets.$inferSelect;
+export type MultiWalletAddress = typeof multiWalletAddresses.$inferSelect;
+export type ZkChatMessage = typeof zkChatMessages.$inferSelect;
+export type MiningReward = typeof miningRewards.$inferSelect;


### PR DESCRIPTION
## Summary
- add database schema for wallets, multi-wallet addresses, zk chat messages, and mining rewards

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd webapp && npm test` *(fails: Missing script: "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68984fd2bd9c833396c67c28b20503ee