### PR TITLE
feat: add express routes and websocket server

### DIFF
--- a/server/PeerBalanceManager.ts
+++ b/server/PeerBalanceManager.ts
@@ -1,0 +1,6 @@
+export default class PeerBalanceManager {
+  issueReward(): void {
+    // placeholder for reward issuance logic
+    console.log('Reward issued to peers');
+  }
+}

--- a/server/qnnValidator.ts
+++ b/server/qnnValidator.ts
@@ -1,0 +1,6 @@
+export default {
+  async validateTransaction(tx: unknown): Promise<boolean> {
+    console.log('Validating transaction', tx);
+    return true;
+  }
+};

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,0 +1,80 @@
+import express, { Express, Request, Response } from 'express';
+import { createServer, Server } from 'http';
+import { WebSocketServer, WebSocket } from 'ws';
+import crypto from 'crypto';
+import PeerBalanceManager from './PeerBalanceManager';
+import qnnValidator from './qnnValidator';
+
+// External dependencies provided by the runtime environment
+// These are declared here to satisfy TypeScript without explicit imports.
+declare const db: unknown;
+declare const wallets: unknown;
+declare const persistentWallet: unknown;
+declare const storage: unknown;
+
+const connectedPeers = new Set<WebSocket>();
+const peerBalanceManager = new PeerBalanceManager();
+
+export async function registerRoutes(app: Express): Promise<Server> {
+  app.use(express.json());
+
+  const server = createServer(app);
+  const wss = new WebSocketServer({ server, path: '/ws' });
+
+  wss.on('connection', (ws: WebSocket) => {
+    connectedPeers.add(ws);
+
+    ws.on('message', async (data: WebSocket.RawData) => {
+      try {
+        const message = JSON.parse(data.toString());
+        if (message.type === 'new_transaction') {
+          await qnnValidator.validateTransaction(message.payload);
+        }
+      } catch (err) {
+        console.error('Failed to process message', err);
+      }
+    });
+
+    ws.on('close', () => {
+      connectedPeers.delete(ws);
+    });
+  });
+
+  app.get('/api/wallet/status', (_req: Request, res: Response) => {
+    try {
+      res.json({ db, wallets, persistentWallet, storage });
+    } catch {
+      res.status(500).json({ error: 'Unable to fetch status' });
+    }
+  });
+
+  const miningStats = { active: false, rewardsIssued: 0 };
+  let miningInterval: NodeJS.Timeout | null = null;
+
+  app.post('/api/mining/start', (_req: Request, res: Response) => {
+    miningStats.active = !miningStats.active;
+    if (miningStats.active) {
+      miningInterval = setInterval(() => {
+        peerBalanceManager.issueReward();
+        miningStats.rewardsIssued += 1;
+      }, 10000);
+    } else if (miningInterval) {
+      clearInterval(miningInterval);
+      miningInterval = null;
+    }
+    res.json(miningStats);
+  });
+
+  app.get('/api/wallet/multi-addresses', (_req: Request, res: Response) => {
+    const coins = ['BTC', 'ETH', 'USDT', 'USDC'];
+    const addresses = coins.reduce<Record<string, string>>((acc, coin) => {
+      const hash = crypto.createHash('sha256').update(coin).digest('hex');
+      acc[coin.toLowerCase()] = hash.slice(0, 34);
+      return acc;
+    }, {});
+    res.json(addresses);
+  });
+
+  return server;
+}
+


### PR DESCRIPTION
## Summary
- initialize Express/HTTP server wiring with WebSocket support and mining API routes
- add placeholders for balance manager and validator integration

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68984fd50b1c8333be07fb0184924952