### PR TITLE
Add TypeScript server scaffolding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "547-blockchain",
+  "version": "1.0.0",
+  "description": "ENJOY",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/server/index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "ws": "^8.13.0",
+    "drizzle-orm": "^0.29.4",
+    "sqlite3": "^5.1.6"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,1 @@
+// placeholder server entry

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -1,0 +1,1 @@
+// shared placeholder module

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": ".",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["server", "shared"]
+}


### PR DESCRIPTION
## Summary
- add Node-oriented TypeScript config compiling `server` and `shared`
- initialize package.json with server build/start scripts and dependencies
- stub `server` and `shared` modules for compilation

## Testing
- `npm test` *(fails: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68984fd6e2f88333b7a3e112a46f6065